### PR TITLE
Add ability to set uid and name in kibana user space resource

### DIFF
--- a/docs/resources/kibana_user_space.md
+++ b/docs/resources/kibana_user_space.md
@@ -12,7 +12,8 @@ It will create `space` called `terraform-test` with some features disabled.
 
 ```tf
 resource kibana_user_space "test" {
-  name 				= "terraform-test"
+  uid 				= "terraform-test"
+  name              = "My terraform test"
   description 		= "test"
   initials			= "tt"
   color				= "#000000"
@@ -23,7 +24,8 @@ resource kibana_user_space "test" {
 ## Argument Reference
 
 ***The following arguments are supported:***
-  - **name**: (required) The user space name to create
+  - **uid**: (required) The user space id to create
+  - **name**: (optional) The name of user space. If not specify, it the same as `uid`.
   - **description**: (optional) The description for user space
   - **disabled_features**: (optional) The list of features you should disabled for this user space.
   - **initials**: (optional) The initial for user space

--- a/kb/resource_kibana_copy_object_test.go
+++ b/kb/resource_kibana_copy_object_test.go
@@ -92,13 +92,13 @@ resource kibana_object "test" {
 }
 
 resource kibana_user_space "test" {
-  name 				= "terraform-test2"
+  uid 				= "terraform-test2"
 }
 
 resource kibana_copy_object "test" {
   name 				= "terraform-test2"
   source_space		= "default"
-  target_spaces		= ["${kibana_user_space.test.name}"]
+  target_spaces		= ["${kibana_user_space.test.uid}"]
   object {
 	  id   = "test"
 	  type = "index-pattern"

--- a/kb/resource_kibana_userspace_test.go
+++ b/kb/resource_kibana_userspace_test.go
@@ -85,7 +85,7 @@ func testCheckKibanaUserSpaceDestroy(s *terraform.State) error {
 
 var testKibanaUserSpace = `
 resource "kibana_user_space" "test" {
-  name 				= "terraform-test"
+  uid 				= "terraform-test"
   description 		= "test"
   initials			= "tt"
   color				= "#000000"


### PR DESCRIPTION
Signed-off-by: disaster37 <linuxworkgroup@hotmail.com>

Fix enhance #19
You can now set `uid` (user space id) and `name` (user space name) on resource `kibana_user_space`.
If you not set `name`, it use the same value as `uid`.

## Breaking change
You need to rename field `name` to `uid` and set `name` if you want.


