### PR TITLE
Feature: kibana_host Terraform Data Source

### DIFF
--- a/docs/datasources/kibana_host.md
+++ b/docs/datasources/kibana_host.md
@@ -1,0 +1,24 @@
+# kibana_host Data Source
+
+This resource permit to retrieve the Kibana connection settings.
+
+***Supported Kibana version:***
+
+- v7
+
+## Example Usage
+
+```tf
+data kibana_host "test" {
+}
+```
+
+## Argument Reference
+
+NA
+
+## Attribute Reference
+
+- **url**: The Kibana URL
+- **username**: The username to use to connect to Kibana. If empty, no authentication is needed
+- **password**: The password to use to connect to Kibana. If empty, no authentication is needed

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,14 @@ provider "kibana" {
 - **retry**: (optional) The number of time you should to retry connexion befaore exist with error. Default to `6`.
 - **wait_before_retry**: (optional) The number of time in second we wait before each connexion retry. Default to `10`.
 
-
-## Resource / Data
+## Resource
 
 - [kibana_user_space](resources/kibana_user_space.md)
 - [kibana_role](resources/kibana_role.md)
 - [kibana_object](resources/kibana_object.md)
 - [kibana_logstash_pipeline](resources/kibana_logstash_pipeline.md)
 - [kibana_copy_object](resources/kibana_copy_object.md)
+
+## Data Source
+
+- [kibana_host](datasources/kibana_host.md)

--- a/kb/data_source_kibana_host.go
+++ b/kb/data_source_kibana_host.go
@@ -1,0 +1,54 @@
+// Return the connection settings of Kibana
+// Supported version:
+//  - v7
+
+package kb
+
+import (
+	kibana "github.com/disaster37/go-kibana-rest/v7"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceKibanaHost() *schema.Resource {
+	return &schema.Resource{
+		Description: "`kibana_host` can be used to retrieve the Kibana connection settings.",
+		Read:        dataSourceKibanaHostRead,
+
+		Schema: map[string]*schema.Schema{
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Kibana URL",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Username to use to connect to Kibana using basic auth",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Password to use to connect to Kibana using basic auth",
+			},
+		},
+	}
+}
+
+func dataSourceKibanaHostRead(d *schema.ResourceData, m interface{}) error {
+	var url string
+	var username string
+	var password string
+
+	conf := m.(*kibana.Client)
+
+	url = conf.Client.HostURL
+	username = conf.Client.UserInfo.Username
+	password = conf.Client.UserInfo.Password
+
+	d.SetId(url)
+	d.Set("url", url)
+	d.Set("username", username)
+	d.Set("password", password)
+
+	return nil
+}

--- a/kb/data_source_kibana_host_test.go
+++ b/kb/data_source_kibana_host_test.go
@@ -1,0 +1,40 @@
+package kb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceKibanaHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceKibanaHost,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDataSourceKibanaHost("kibana_host.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckDataSourceKibanaHost(name string) resource.TestCheckFunc {
+	var url, username, password resource.TestCheckFunc
+
+	url = resource.TestCheckResourceAttr("data."+name, "url", os.Getenv("KIBANA_URL"))
+	username = resource.TestCheckResourceAttr("data."+name, "username", os.Getenv("KIBANA_USERNAME"))
+	password = resource.TestCheckResourceAttr("data."+name, "password", os.Getenv("KIBANA_PASSWORD"))
+
+	return resource.ComposeAggregateTestCheckFunc(url, username, password)
+}
+
+var testDataSourceKibanaHost = `
+data "kibana_host" "test" {
+}
+`

--- a/kb/provider.go
+++ b/kb/provider.go
@@ -69,6 +69,10 @@ func Provider() *schema.Provider {
 			"kibana_copy_object":       resourceKibanaCopyObject(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"kibana_host": dataSourceKibanaHost(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/tests/kibana_host/run.sh
+++ b/tests/kibana_host/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cat <<EOT > ${HOME}/.terraformrc
+provider_installation {
+    filesystem_mirror {
+        path    = "${PWD}/../../registry"
+        include = ["registry.terraform.io/disaster37/kibana"]
+    }
+    direct {
+        exclude = ["registry.terraform.io/disaster37/kibana"]
+    }
+}
+EOT
+
+rm -rf .terraform*
+terraform init
+TF_LOG_PROVIDER=DEBUG terraform apply

--- a/tests/kibana_host/terraform.tf
+++ b/tests/kibana_host/terraform.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    kibana = {
+      source = "disaster37/kibana"
+      version = "1.0.0"
+    }
+  }
+
+  
+}
+
+provider "kibana" {
+    url      = "http://kibana:5601"
+    username = "elastic"
+    password = "changeme"
+}
+
+
+data "kibana_host" "test" {
+}
+
+
+output "url" {
+  value = data.kibana_host.test.url
+}
+
+output "username" {
+  value = data.kibana_host.test.username
+}
+
+output "password" {
+  value = data.kibana_host.test.password
+}


### PR DESCRIPTION
### Feature: **kibana_host** Terraform Data Source

#### Goal
This feature provides a Terraform Data Source to retrieve the Kibana connection settings:
- The Kibana URL
- The Kibana user
- The Kibana password

#### Why this feature ?
To be able to invoke a local executable (by `local-exec`) to call Kibana's API not managed by this provider by using the parameters which its defined (`url`, `username` and `password`).

#### Sample usage case
In below sample, we call a shell script to customize the space created. The shell script uses `curl` command lines to call APIs not managed by the provider. For that, it's necessary to know the URL and the authentication fields of Kibana. The goal of this feature is to get these settings directly from the provider and not add additional and duplicate variables.

```tf
data "kibana_host" "sample" {
}

# Create the team space
resource "kibana_user_space" "team" {
  uid               = lower(replace(var.space_name, " ", "-"))
  name              = var.space_name
  description       = var.space_description
  initials          = var.space_initials
  color             = var.space_color
  disabled_features = local.disabled_features

  # Add a default index pattern and update the Observability's log stream settings
  provisioner "local-exec" {
    command = "sh ./custom-space.sh ${data.kibana_host.sample.url} ${data.kibana_host.sample.username} ${data.kibana_host.sample.password }${self.uid}"
    working_dir = path.module
  }
}
```

#### Pull Request
@disaster37, Thanks for your work and I hope that you accept to add this feature into your project.