### PR TITLE
fix(kibana_role): Use Elasticsearch Indices query as a string

### DIFF
--- a/kb/resource_kibana_role.go
+++ b/kb/resource_kibana_role.go
@@ -333,7 +333,7 @@ func buildKibanaRoleElasticsearchIndice(raws []interface{}) ([]kbapi.KibanaRoleE
 		kibanaRoleElasticsearchIndice := kbapi.KibanaRoleElasticsearchIndice{
 			Names:         convertArrayInterfaceToArrayString(m["names"].(*schema.Set).List()),
 			Privileges:    convertArrayInterfaceToArrayString(m["privileges"].(*schema.Set).List()),
-			Query:         optionalInterfaceJSON(m["query"].(string)),
+			Query:         m["query"].(string),
 			FieldSecurity: fieldSecurity,
 		}
 

--- a/kb/resource_kibana_role.go
+++ b/kb/resource_kibana_role.go
@@ -445,8 +445,7 @@ func flattenKibanaRoleElasticsearchMappingIndices(krei kbapi.KibanaRoleElasticse
 
 	tfMap["names"] = krei.Names
 	tfMap["privileges"] = krei.Privileges
-	flattenQuerry, err := convertInterfaceToJsonString(krei.Query)
-	tfMap["query"] = flattenQuerry
+	tfMap["query"] = krei.Query
 
 	flattenFieldSecurity, err := convertInterfaceToJsonString(krei.FieldSecurity)
 	if err != nil {


### PR DESCRIPTION
As shown in the issue #27:

The query of an Elasticsearch Index privelege must be a string.