### PR TITLE
Fix parameter typo in kibana_logstash_pipeline resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See LICENSE.
 1. Fork it ( https://github.com/disaster37/terraform-provider-kibana/fork )
 2. Go to the right branch (7.x for Kibana 7) (`git checkout 8.x`)
 3. Create your feature branch (`git checkout -b my-new-feature`)
-4. Add feature, add acceptance test and tets your code (`KIBANA_URL=http://127.0.0.1:5601 KIBANA_USERNAME=elastic KIBANA_PASSWORD=changeme make testacc`)
+4. Add feature, add acceptance test and test your code (`KIBANA_URL=http://127.0.0.1:5601 KIBANA_USERNAME=elastic KIBANA_PASSWORD=changeme make testacc`)
 5. Commit your changes (`git commit -am 'Add some feature'`)
 6. Push to the branch (`git push origin my-new-feature`)
 7. Create a new Pull Request

--- a/docs/resources/kibana_logstash_pipeline.md
+++ b/docs/resources/kibana_logstash_pipeline.md
@@ -36,7 +36,7 @@ resource kibana_logstash_pipeline "test" {
   - **pipeline_batch_size**: (optional)
   - **pipeline_batch_delay**: (optional)
   - **pipeline_ecs_compatibility**: (optional)
-  - **pipeline_ordored**: (optional)
+  - **pipeline_ordered**: (optional)
   - **queue_type**: (optional)
   - **queue_max_bytes**: (optional)
   - **queue_checkpoint_writes**: (optional)

--- a/kb/resource_kibana_logstash_pipeline.go
+++ b/kb/resource_kibana_logstash_pipeline.go
@@ -67,7 +67,7 @@ func resourceKibanaLogstashPipeline() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"pipeline_ordored": {
+						"pipeline_ordered": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -151,7 +151,7 @@ func resourceKibanaLogstashPipelineRead(ctx context.Context, d *schema.ResourceD
 			"pipeline_batch_size":        logstashPiepeline.Settings["pipeline.batch.size"],
 			"pipeline_batch_delay":       logstashPiepeline.Settings["pipeline.batch.delay"],
 			"pipeline_ecs_compatibility": logstashPiepeline.Settings["pipeline.ecs_compatibility"],
-			"pipeline_ordored":           logstashPiepeline.Settings["pipeline.ordered"],
+			"pipeline_ordered":           logstashPiepeline.Settings["pipeline.ordered"],
 			"queue_type":                 logstashPiepeline.Settings["queue.type"],
 			"queue_max_bytes":            logstashPiepeline.Settings["queue.max_bytes"],
 			"queue_checkpoint_writes":    logstashPiepeline.Settings["queue.checkpoint.writes"],
@@ -238,7 +238,7 @@ func createOrUpdateLogstashPipeline(d *schema.ResourceData, meta interface{}) (*
 				logstashPipeline.Settings["pipeline.batch.delay"] = value
 			case "pipeline_ecs_compatibility":
 				logstashPipeline.Settings["pipeline.ecs_compatibility"] = value
-			case "pipeline_ordored":
+			case "pipeline_ordered":
 				logstashPipeline.Settings["pipeline.ordered"] = value
 			case "queue_type":
 				logstashPipeline.Settings["queue.type"] = value


### PR DESCRIPTION
Fixing typo issue during `kibana_logstash_pipeline` resource deployment.

```
Error: Unsupported attribute on main.tf line 206, in module "kibana_logstash_pipeline" "main":
206:   pipeline_ordered = "auto"

An argument named "pipeline_ordered" is not expected here. Did you mean "pipeline_ordored"?
```

Changing `pipeline_ordored` parameter to `pipeline_ordered`