### PR TITLE
Supress diff for created_at, managed and typeMigrationVersion

### DIFF
--- a/kb/diff_suppress_funcs.go
+++ b/kb/diff_suppress_funcs.go
@@ -101,6 +101,9 @@ func suppressEquivalentNDJSON(k, old, new string, d *schema.ResourceData) bool {
 		"migrationVersion":     nil,
 		"references":           nil,
 		"sort":                 nil,
+		"created_at":           nil,
+		"managed":              nil,
+		"typeMigrationVersion": nil,
 	}
 
 	// NDJSON mean sthat each line correspond to JSON struct


### PR DESCRIPTION
Getting these changes on a v8.10.1 cluster every time

![image](https://github.com/disaster37/terraform-provider-kibana/assets/3604363/b6ae440a-80f7-4414-8f79-371a79b1597d)
